### PR TITLE
Add get_all/1 helper

### DIFF
--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -88,6 +88,14 @@ defmodule PropertyTable do
   end
 
   @doc """
+  Get all properties for a table
+
+  Same as get_by_prefix(table_id(), [])
+  """
+  @spec get_all(table_id()) :: [property_value()]
+  def get_all(table), do: get_by_prefix(table, [])
+
+  @doc """
   Get a list of all properties matching the specified prefix
   """
   @spec get_by_prefix(table_id(), property()) :: [{property(), value()}]


### PR DESCRIPTION
Sometimes its not as clear that you can get all properties of a table by just using an empty prefix. So this adds `PropertyTable.get_all/1` helper function to specify that ability with a doc