### PR TITLE
Preserve properties across Table GenServer crashes

### DIFF
--- a/lib/property_table/supervisor.ex
+++ b/lib/property_table/supervisor.ex
@@ -13,8 +13,10 @@ defmodule PropertyTable.Supervisor do
     properties = Keyword.get(options, :properties, [])
     registry_name = registry_name(name)
 
+    PropertyTable.Table.create_ets_table(name, properties)
+
     children = [
-      {PropertyTable.Table, {name, registry_name, properties}},
+      {PropertyTable.Table, {name, registry_name}},
       {Registry, [keys: :duplicate, name: registry_name]}
     ]
 


### PR DESCRIPTION
This moves the ETS table ownership to the supervisor so that the Table
GenServer can crash without losing properties. The main change involves
seeding the table earlier so that restarting the Table GenServer doesn't
overwrite changes to the original properties.
