### PR TITLE
Add ability to persist a property table safely to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ PropertyTable consumers express their interest in properties using "patterns". A
 wildcards. This allows one to create hierarchical key-value stores, map-based
 stores, or just simple key-value stores with notifications.
 
-PropertyTable is not persistent. Keys and values are backed by ETS.
+PropertyTable is optionally persistent to disk. Keys and values are backed by ETS.
 <!-- MODULEDOC -->
 
 ## Example

--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -52,7 +52,8 @@ defmodule PropertyTable do
 
   Persistent options:
 
-  You MUST set at least `:persist_data_path` for any of the other options to be respected!
+  * You MUST set at least `:persist_data_path` for any of the other options to be respected!
+  * If the table can restore its data from disk, it will IGNORE your initial `:properties` value.
 
   * `:persist_data_path` - set to a directory where PropertyTable will
     persist the contents of the table to disk, snapshots will also be stored here.

--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -58,7 +58,6 @@ defmodule PropertyTable do
     persist the contents of the table to disk, snapshots will also be stored here.
   * `:persist_interval` - if set PropertyTable will persist the contents of
     tables to disk in intervals of the provided value (in milliseconds) automatically.
-    it is saved to disk. This is useful for keeping track of "versions" of the property layouts.
   * `:persist_max_snapshots` - Maximum number of manual snapshots to keep on disk before they
     are replaced - (oldest snapshots are replaced first.)
   """

--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -61,6 +61,7 @@ defmodule PropertyTable do
     tables to disk in intervals of the provided value (in milliseconds) automatically.
   * `:persist_max_snapshots` - Maximum number of manual snapshots to keep on disk before they
     are replaced - (oldest snapshots are replaced first.)
+  * `:persist_compression` - `0..9` range to compress the terms when written to disk, see `:erlang.term_to_binary/2`
   """
   @spec start_link([option()]) :: Supervisor.on_start()
   def start_link(options) do
@@ -277,7 +278,8 @@ defmodule PropertyTable do
         data_directory: Keyword.get(options, :persist_data_path),
         table_name: table_name,
         interval: Keyword.get(options, :persist_interval),
-        max_snapshots: Keyword.get(options, :persist_max_snapshots)
+        max_snapshots: Keyword.get(options, :persist_max_snapshots),
+        compression: Keyword.get(options, :persist_compression)
       ]
       |> Enum.filter(fn {_, v} -> v != nil end)
     else

--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -271,7 +271,8 @@ defmodule PropertyTable do
     if Keyword.has_key?(options, :persist_data_path) do
       table_name = Keyword.get(options, :name) |> Atom.to_string()
 
-      # Set persistence options, and clean out any nil values, they will be filled with defaults in `PropertyTable.Persist`
+      # Set persistence options, and clean out any nil values
+      # they will be filled with defaults in `PropertyTable.Persist`
       [
         data_directory: Keyword.get(options, :persist_data_path),
         table_name: table_name,

--- a/lib/property_table/persist.ex
+++ b/lib/property_table/persist.ex
@@ -94,6 +94,7 @@ defmodule PropertyTable.Persist do
         end)
 
         :ok
+
       error ->
         error
     end
@@ -109,13 +110,9 @@ defmodule PropertyTable.Persist do
     options = take_options(options)
     persist_to_disk(table, options)
 
-    snapshot_id =
-      :ets.tab2list(table)
-      |> :erlang.phash2()
-      |> to_string()
+    snapshot_id = :crypto.strong_rand_bytes(8) |> Base.encode16()
 
-    timestamp = DateTime.utc_now() |> to_string()
-    full_snapshot_name = "#{timestamp}_#{snapshot_id}"
+    full_snapshot_name = "#{snapshot_id}"
     stable_path = get_path(:stable, options)
     snapshot_path = get_path(:snapshot, options, full_snapshot_name)
 

--- a/lib/property_table/persist.ex
+++ b/lib/property_table/persist.ex
@@ -44,10 +44,14 @@ defmodule PropertyTable.Persist do
       File.rename!(stable_path, backup_path)
 
       Logger.debug("Writing PropertyTable to #{stable_path}")
-      :ok = :ets.tab2file(table, stable_path |> to_charlist(), extended_info: [:md5sum])
+
+      :ok =
+        :ets.tab2file(table, stable_path |> to_charlist(), extended_info: [:md5sum], sync: true)
     else
       Logger.debug("Writing PropertyTable to #{stable_path}")
-      :ok = :ets.tab2file(table, stable_path |> to_charlist(), extended_info: [:md5sum])
+
+      :ok =
+        :ets.tab2file(table, stable_path |> to_charlist(), extended_info: [:md5sum], sync: true)
     end
 
     :ok

--- a/lib/property_table/persist.ex
+++ b/lib/property_table/persist.ex
@@ -45,13 +45,13 @@ defmodule PropertyTable.Persist do
       File.rename!(stable_path, backup_path)
 
       Logger.debug("Writing PropertyTable to #{stable_path}")
-      :ets.tab2file(table, stable_path |> to_charlist())
+      :ok = :ets.tab2file(table, stable_path |> to_charlist())
 
       Logger.debug("Deleting backup file")
       File.rm!(backup_path)
     else
       Logger.debug("Writing PropertyTable to #{stable_path}")
-      :ets.tab2file(table, stable_path |> to_charlist())
+      :ok = :ets.tab2file(table, stable_path |> to_charlist())
     end
 
     :ok
@@ -88,7 +88,7 @@ defmodule PropertyTable.Persist do
     end
   end
 
-  @spec save_snapshot(reference() | atom(), Keyword.t()) :: :ok | no_return()
+  @spec save_snapshot(reference() | atom(), Keyword.t()) :: {:ok, String.t()} | no_return()
   def save_snapshot(table, options) do
     options = take_options(options)
     persist_to_disk(table, options)
@@ -108,7 +108,7 @@ defmodule PropertyTable.Persist do
     {:ok, snapshot_id}
   end
 
-  @spec restore_snapshot(Keyword.t(), String.t()) :: :ok | no_return()
+  @spec restore_snapshot(Keyword.t(), String.t()) :: :ok | {:error, :enoent} | no_return()
   def restore_snapshot(options, snapshot_id) do
     options = take_options(options)
     stable_path = get_path(:stable, options)

--- a/lib/property_table/persist.ex
+++ b/lib/property_table/persist.ex
@@ -194,24 +194,24 @@ defmodule PropertyTable.Persist do
   defp get_path(:stable, options) do
     dir = Path.join(options[:data_directory], options[:table_name])
     File.mkdir_p!(dir)
-    Path.join(options[:data_directory], [options[:table_name], "/", @data_stable_name])
+    Path.join([options[:data_directory], options[:table_name], @data_stable_name])
   end
 
   defp get_path(:backup, options) do
     dir = Path.join(options[:data_directory], options[:table_name])
     File.mkdir_p!(dir)
-    Path.join(options[:data_directory], [options[:table_name], "/", @data_backup_name])
+    Path.join([options[:data_directory], options[:table_name], @data_backup_name])
   end
 
   defp get_path(:snapshot, options) do
-    dir = Path.join(options[:data_directory], [options[:table_name], "/", "snapshots"])
+    dir = Path.join([options[:data_directory], options[:table_name], "snapshots"])
     File.mkdir_p!(dir)
 
     dir
   end
 
   defp get_path(:snapshot, options, snapshot_name) do
-    dir = Path.join(options[:data_directory], [options[:table_name], "/", "snapshots"])
+    dir = Path.join([options[:data_directory], options[:table_name], "snapshots"])
     File.mkdir_p!(dir)
 
     Path.join(dir, "#{snapshot_name}")

--- a/lib/property_table/persist.ex
+++ b/lib/property_table/persist.ex
@@ -221,7 +221,7 @@ defmodule PropertyTable.Persist do
       Logger.warn("Number of snapshots is over configured max: #{options[:max_snapshots]}")
       Logger.warn("Deleting oldest snapshot: #{to_delete_id}")
 
-      to_delete_path =  get_path(:snapshot, options, to_delete_id)
+      to_delete_path = get_path(:snapshot, options, to_delete_id)
 
       File.rm!(to_delete_path)
     end

--- a/lib/property_table/persist.ex
+++ b/lib/property_table/persist.ex
@@ -93,7 +93,11 @@ defmodule PropertyTable.Persist do
     options = take_options(options)
     persist_to_disk(table, options)
 
-    snapshot_id = :crypto.strong_rand_bytes(8) |> Base.encode16()
+    snapshot_id =
+      :ets.tab2list(table)
+      |> :erlang.phash2()
+      |> to_string()
+
     timestamp = DateTime.utc_now() |> to_string()
     full_snapshot_name = "#{timestamp}_#{snapshot_id}"
     stable_path = get_path(:stable, options)

--- a/lib/property_table/persist.ex
+++ b/lib/property_table/persist.ex
@@ -1,0 +1,190 @@
+defmodule PropertyTable.Persist do
+  @moduledoc """
+  This module contains logic to persist the content of a PropertyTable to disk
+
+  It does so in the following manner:
+
+  1. If a `prop_table.db` file exists in the data directory, rename it to `prop_table.db.backup`
+  2. Write the data of the ETS table to the file `prop_table.db`
+  3. Delete the backup file
+
+  When you wish to restore a property table from disk, the following will occur:
+
+  1. If a `prop_table.db.backup` exists in the data directory, it means we failed to write to disk in the past (possibly due to a power failure or app crash)
+    1a. Delete the `prop_table.db` file as it's probably corrupted
+    1b. Move `prop_table.db.backup` back to `prop_table.db`
+  2. Restore the table from `prop_table.db`
+
+  You can also manually request "snapshots" of the property table, this will immediately do the procedure for persisting to disk above, then a duplicate of the
+  current `prop_table.db` file will be copied into the `snapshots/` directory with a timestamp added to the file name. `max_snapshots` in the options keyword list can be used
+  to limit the number of snapshots saved in the `snapshots/` directory, if the limit is reached during a snapshot operation, the oldest snapshot will be deleted from disk.
+  """
+
+  require Logger
+
+  # Options for persisting to disk, and their default values
+  @persist_options %{
+    data_directory: "/data/property_table",
+    table_name: nil,
+    max_snapshots: 25
+  }
+
+  @data_stable_name "prop_table.db"
+  @data_backup_name "prop_table.db.backup"
+
+  @spec persist_to_disk(reference() | atom(), Keyword.t()) :: :ok | no_return()
+  def persist_to_disk(table, options) do
+    options = take_options(options)
+
+    stable_path = get_path(:stable, options)
+    backup_path = get_path(:backup, options)
+
+    if File.exists?(stable_path) do
+      # Move the current stable data file to the backup path
+      Logger.debug("Moving stable data file to backup: #{stable_path} => #{backup_path}")
+      File.rename!(stable_path, backup_path)
+
+      Logger.debug("Writing PropertyTable to #{stable_path}")
+      :ets.tab2file(table, stable_path |> to_charlist())
+
+      Logger.debug("Deleting backup file")
+      File.rm!(backup_path)
+    else
+      Logger.debug("Writing PropertyTable to #{stable_path}")
+      :ets.tab2file(table, stable_path |> to_charlist())
+    end
+
+    :ok
+  end
+
+  @spec restore_from_disk(Keyword.t()) :: {:ok, reference() | atom()} | {:error, atom()}
+  def restore_from_disk(options) do
+    options = take_options(options)
+
+    stable_path = get_path(:stable, options)
+    backup_path = get_path(:backup, options)
+
+    # Check if a backup file still exists, if so we may have been interrupted during our last write operation
+    # restore from that file instead by moving it to the stable path
+    if File.exists?(backup_path) do
+      Logger.warn(
+        "Found a backup PropertyTable path: #{backup_path}, this may indicate that the table was not written to disk fully last time!"
+      )
+
+      Logger.warn(
+        "\tWe will restore this table from the backup file, but there may be data lost since the last write to disk!"
+      )
+
+      Logger.debug("Moving backup file to stable file #{backup_path} => #{stable_path}")
+      File.rename!(backup_path, stable_path)
+    end
+
+    # Restore from the stable path
+    if File.exists?(stable_path) do
+      Logger.debug("Restoring PropertyTable from disk: #{stable_path}")
+      to_charlist(stable_path) |> :ets.file2tab()
+    else
+      {:error, :enoent}
+    end
+  end
+
+  @spec save_snapshot(reference() | atom(), Keyword.t()) :: :ok | no_return()
+  def save_snapshot(table, options) do
+    options = take_options(options)
+    persist_to_disk(table, options)
+
+    snapshot_id = :crypto.strong_rand_bytes(8) |> Base.encode16()
+    timestamp = DateTime.utc_now() |> to_string()
+    full_snapshot_name = "#{timestamp}_#{snapshot_id}"
+    stable_path = get_path(:stable, options)
+    snapshot_path = get_path(:snapshot, options, full_snapshot_name)
+
+    # Move file to snapshot directory
+    Logger.debug("Creating table file snapshot: #{snapshot_path}")
+    File.copy!(stable_path, snapshot_path)
+
+    maybe_clean_old_snapshots(options)
+
+    {:ok, snapshot_id}
+  end
+
+  @spec restore_snapshot(Keyword.t(), String.t()) :: :ok | no_return()
+  def restore_snapshot(options, snapshot_id) do
+    options = take_options(options)
+    stable_path = get_path(:stable, options)
+    snapshots_path = get_path(:snapshot, options) |> Path.join("*_#{snapshot_id}")
+    found_snapshot = Path.wildcard(snapshots_path)
+
+    if length(found_snapshot) != 1 do
+      {:error, :enoent}
+    else
+      [to_restore] = found_snapshot
+
+      # Copy the found snapshot in place of the current stable db path
+      Logger.debug("Restoring table file snapshot: #{to_restore} => #{stable_path}")
+      File.copy!(to_restore, stable_path)
+
+      :ok
+    end
+  end
+
+  @spec get_snapshot_list(Keyword.t()) :: [{String.t(), String.t()}] | no_return()
+  def get_snapshot_list(options) do
+    options = take_options(options)
+    snapshot_path = get_path(:snapshot, options, "*")
+
+    Path.wildcard(snapshot_path)
+    |> Enum.sort()
+    |> Enum.map(fn file_path ->
+      snapshot_id = String.split(file_path, "_") |> List.last()
+      full_name = Path.basename(file_path)
+      {snapshot_id, full_name}
+    end)
+  end
+
+  defp take_options(options) when is_list(options) do
+    @persist_options
+    |> Enum.map(fn {key_name, default_value} ->
+      {key_name, Keyword.get(options, key_name, default_value)}
+    end)
+  end
+
+  defp get_path(:stable, options) do
+    dir = Path.join(options[:data_directory], options[:table_name])
+    File.mkdir_p!(dir)
+    Path.join(options[:data_directory], [options[:table_name], "/", @data_stable_name])
+  end
+
+  defp get_path(:backup, options) do
+    dir = Path.join(options[:data_directory], options[:table_name])
+    File.mkdir_p!(dir)
+    Path.join(options[:data_directory], [options[:table_name], "/", @data_backup_name])
+  end
+
+  defp get_path(:snapshot, options) do
+    dir = Path.join(options[:data_directory], [options[:table_name], "/", "snapshots"])
+    File.mkdir_p!(dir)
+
+    dir
+  end
+
+  defp get_path(:snapshot, options, snapshot_name) do
+    dir = Path.join(options[:data_directory], [options[:table_name], "/", "snapshots"])
+    File.mkdir_p!(dir)
+
+    Path.join(dir, "snapshot_#{snapshot_name}")
+  end
+
+  defp maybe_clean_old_snapshots(options) do
+    snapshot_path = get_path(:snapshot, options, "*")
+    snapshot_files = Path.wildcard(snapshot_path) |> Enum.sort()
+
+    if length(snapshot_files) > options[:max_snapshots] do
+      to_delete = List.first(snapshot_files)
+      Logger.warn("Number of snapshots is over configured max: #{options[:max_snapshots]}")
+      Logger.warn("Deleting oldest snapshot: #{to_delete}")
+
+      File.rm!(to_delete)
+    end
+  end
+end

--- a/lib/property_table/persist_file.ex
+++ b/lib/property_table/persist_file.ex
@@ -1,0 +1,71 @@
+defmodule PropertyTable.PersistFile do
+  @moduledoc """
+  This module contains methods to aid in writing the contents of a PropertyTable to a custom file format.
+
+  The structure of the format is the following:
+
+    ```
+    +------------------------------+
+    | HEADER 'PTABLE'              | Used to initially validate the file [0x00]
+    +------------------------------+
+    | FILE VERSION (uint8)         | Used to track the internal PropertyTable structure of the file [0x06]
+    +------------------------------+
+    | RESERVED (8 bits)            | Reserved [0x07]
+    +------------------------------+
+    | PAYLOAD SIZE (uint64)        | Length in bytes of the payload that follows [0x08]
+    +------------------------------+
+    | PAYLOAD BYTES (above size)   | Raw erlang term bytes of the table contents [0x10]
+    +------------------------------+
+    | PAYLOAD HASH (MD5 128 bits)  | MD5 Checksum of the bytes when they were written, ensures table integrity [0x10 + payload_size]
+    +------------------------------+
+    ```
+
+  """
+
+  # PTABLE header bytes
+  @magic_file_header <<80, 84, 65, 66, 76, 69>>
+
+  # Presently this version number is not used for anything, but if we want to change
+  # the internal format of how we store the table, we can use this to version the layouts
+  @file_version 1
+
+  @spec decode_file(binary) :: {:error, :bad_checksum | :bad_file} | {:ok, binary}
+  def decode_file(file_path) when is_binary(file_path) do
+    file_content = File.read!(file_path)
+    case decode_bitstring(file_content) do
+      {:ok, decoded} -> validate_payload(decoded.payload, decoded.hash)
+      error -> error
+    end
+  end
+
+  @spec encode_binary(binary) :: binary()
+  def encode_binary(table_content_binary) when is_binary(table_content_binary) do
+    payload_length = byte_size(table_content_binary)
+    payload_hash = :crypto.hash(:md5, table_content_binary)
+
+    <<
+      @magic_file_header::binary,
+      @file_version::8,
+      0x0::8, # Reserved byte
+      payload_length::64,
+      table_content_binary::binary,
+      payload_hash::binary
+    >>
+  end
+
+  defp validate_payload(payload, hash) do
+    check_hash = :crypto.hash(:md5, payload)
+    if hash != check_hash do
+      {:error, :bad_checksum}
+    else
+      {:ok, payload}
+    end
+  end
+
+  defp decode_bitstring(<<@magic_file_header, version::8, _reserved::8, payload_len::64, table_content::binary-size(payload_len), payload_hash::binary>>), do: {:ok, %{
+    file_version: version,
+    payload: table_content,
+    hash: payload_hash
+  }}
+  defp decode_bitstring(_), do: {:error, :bad_file}
+end

--- a/lib/property_table/persist_file.ex
+++ b/lib/property_table/persist_file.ex
@@ -39,7 +39,7 @@ defmodule PropertyTable.PersistFile do
     end
   end
 
-  @spec encode_binary(binary) :: binary()
+  @spec encode_binary(binary) :: <<_::64, _::_*8>>
   def encode_binary(table_content_binary) when is_binary(table_content_binary) do
     payload_length = byte_size(table_content_binary)
     payload_hash = :crypto.hash(:md5, table_content_binary)

--- a/lib/property_table/supervisor.ex
+++ b/lib/property_table/supervisor.ex
@@ -10,10 +10,21 @@ defmodule PropertyTable.Supervisor do
       matcher: options.matcher,
       registry: registry_name,
       table: options.table,
-      tuple_events: options.tuple_events
+      tuple_events: options.tuple_events,
+      persistence_options: options.persistence_options
     }
 
-    PropertyTable.Updater.create_ets_table(options.table, options.properties)
+    # Try and restore from disk if persistence options are provided
+    # otherwise just create a new ETS table
+    if options.persistence_options != nil do
+      PropertyTable.Updater.maybe_restore_ets_table(
+        options.table,
+        options.properties,
+        options.persistence_options
+      )
+    else
+      PropertyTable.Updater.create_ets_table(options.table, options.properties)
+    end
 
     children = [
       {Registry, [keys: :duplicate, name: registry_name, partitions: 1]},

--- a/lib/property_table/updater.ex
+++ b/lib/property_table/updater.ex
@@ -47,18 +47,9 @@ defmodule PropertyTable.Updater do
       :ets.delete(table_name)
     end
 
-    case Persist.restore_from_disk(persistence_options) do
-      {:ok, table} ->
-        restored_table_name = :ets.info(table)[:name]
-
-        # Ensure the table loaded from the file will match the table we query later
-        # if for some odd reason the table got renamed...
-        if table_name != restored_table_name do
-          :ets.rename(table, table_name)
-        end
-
-      # If there is no good file to restore from just create a new table
-      {:error, _reason} ->
+    case Persist.restore_from_disk(table_name, persistence_options) do
+      :ok -> :ok
+      {:error, _error_reason} ->
         create_ets_table(table_name, initial_properties)
     end
   end

--- a/lib/property_table/updater.ex
+++ b/lib/property_table/updater.ex
@@ -165,7 +165,7 @@ defmodule PropertyTable.Updater do
   def init(opts) do
     Registry.put_meta(opts.registry, :matcher, opts.matcher)
 
-    maybe_setup_persistence(opts.persistence_options)
+    :ok = maybe_setup_persistence(opts.persistence_options)
 
     {:ok, opts}
   end
@@ -407,7 +407,12 @@ defmodule PropertyTable.Updater do
 
   defp maybe_setup_persistence(options) when is_list(options) do
     if Keyword.has_key?(options, :interval) do
-      :timer.send_interval(options[:interval], :persist)
+      case :timer.send_interval(options[:interval], :persist) do
+        {:error, reason} -> raise "Failed to start persist timer: #{reason}"
+        _ -> :ok
+      end
     end
+
+    :ok
   end
 end

--- a/lib/property_table/updater.ex
+++ b/lib/property_table/updater.ex
@@ -281,8 +281,7 @@ defmodule PropertyTable.Updater do
           maybe_restore_ets_table(state.table, [], state.persistence_options)
           {:reply, :ok, state}
 
-        {:error, :enoent} ->
-          Logger.error("Snapshot with ID #{snapshot_id} was not found! Doing nothing.")
+        {:error, _err} ->
           {:reply, :noop, state}
       end
     end

--- a/lib/property_table/updater.ex
+++ b/lib/property_table/updater.ex
@@ -49,22 +49,16 @@ defmodule PropertyTable.Updater do
 
     case Persist.restore_from_disk(persistence_options) do
       {:ok, table} ->
-        # Insert the initial properties
-        timestamp = System.monotonic_time()
-
-        Enum.each(initial_properties, fn {property, value} ->
-          :ets.insert(table, {property, value, timestamp})
-        end)
-
         restored_table_name = :ets.info(table)[:name]
 
+        # Ensure the table loaded from the file will match the table we query later
+        # if for some odd reason the table got renamed...
         if table_name != restored_table_name do
-          # This rename ensures the table loaded from the file will match the table we query later
           :ets.rename(table, table_name)
         end
 
-      # If there is no file to restore from just create a new table
-      {:error, :enoent} ->
+      # If there is no good file to restore from just create a new table
+      {:error, _reason} ->
         create_ets_table(table_name, initial_properties)
     end
   end

--- a/lib/property_table/updater.ex
+++ b/lib/property_table/updater.ex
@@ -7,6 +7,7 @@ defmodule PropertyTable.Updater do
   use GenServer
 
   alias PropertyTable.Event
+  alias PropertyTable.Persist
 
   require Logger
 
@@ -33,6 +34,39 @@ defmodule PropertyTable.Updater do
     Enum.each(initial_properties, fn {property, value} ->
       :ets.insert(table, {property, value, timestamp})
     end)
+  end
+
+  @spec maybe_restore_ets_table(
+          PropertyTable.table_id(),
+          [PropertyTable.property_value()],
+          Keyword.t()
+        ) :: :ok
+  def maybe_restore_ets_table(table_name, initial_properties, persistence_options) do
+    # if a table with this name already exists, delete it
+    if :ets.info(table_name) != :undefined do
+      :ets.delete(table_name)
+    end
+
+    case Persist.restore_from_disk(persistence_options) do
+      {:ok, table} ->
+        # Insert the initial properties
+        timestamp = System.monotonic_time()
+
+        Enum.each(initial_properties, fn {property, value} ->
+          :ets.insert(table, {property, value, timestamp})
+        end)
+
+        restored_table_name = :ets.info(table)[:name]
+
+        if table_name != restored_table_name do
+          # This rename ensures the table loaded from the file will match the table we query later
+          :ets.rename(table, table_name)
+        end
+
+      # If there is no file to restore from just create a new table
+      {:error, :enoent} ->
+        create_ets_table(table_name, initial_properties)
+    end
   end
 
   @doc false
@@ -94,9 +128,44 @@ defmodule PropertyTable.Updater do
     GenServer.call(server_name(table), {:delete_matches, pattern, System.monotonic_time()})
   end
 
+  @doc """
+  Take a snapshot of the table and save to disk (if persistence is configured)
+  """
+  @spec snapshot(PropertyTable.table_id()) :: {:ok, String.t()} | :noop
+  def snapshot(table) do
+    GenServer.call(server_name(table), :snapshot)
+  end
+
+  @doc """
+  Restore a snapshot by ID (if persistence is configured)
+  """
+  @spec restore_snapshot(PropertyTable.table_id(), String.t()) :: :ok | :noop
+  def restore_snapshot(table, snapshot_id) do
+    GenServer.call(server_name(table), {:restore_snapshot, snapshot_id})
+  end
+
+  @doc """
+  Get a list of snapshots (if persistence is configured)
+  """
+  @spec get_snapshots(PropertyTable.table_id()) :: [{String.t(), String.t()}]
+  def get_snapshots(table) do
+    GenServer.call(server_name(table), :get_snapshots)
+  end
+
+  @doc """
+  Save table to disk immediately (if persistence is configured)
+  """
+  @spec flush_to_disk(PropertyTable.table_id()) :: :ok
+  def flush_to_disk(table) do
+    send(server_name(table), :persist)
+    :ok
+  end
+
   @impl GenServer
   def init(opts) do
     Registry.put_meta(opts.registry, :matcher, opts.matcher)
+
+    maybe_setup_persistence(opts.persistence_options)
 
     {:ok, opts}
   end
@@ -204,6 +273,49 @@ defmodule PropertyTable.Updater do
     {:reply, :ok, state}
   end
 
+  @impl GenServer
+  def handle_call(:snapshot, _from, state) do
+    if state.persistence_options == nil do
+      {:reply, :noop, state}
+    else
+      {:ok, snapshot_id} = Persist.save_snapshot(state.table, state.persistence_options)
+      {:reply, {:ok, snapshot_id}, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_call({:restore_snapshot, snapshot_id}, _from, state) do
+    if state.persistence_options == nil do
+      {:reply, :noop, state}
+    else
+      case Persist.restore_snapshot(state.persistence_options, snapshot_id) do
+        :ok ->
+          # With the snapshot file restore, reload the table from disk like usual
+          maybe_restore_ets_table(state.table, [], state.persistence_options)
+          {:reply, :ok, state}
+
+        {:error, :enoent} ->
+          Logger.error("Snapshot with ID #{snapshot_id} was not found! Doing nothing.")
+          {:reply, :noop, state}
+      end
+    end
+  end
+
+  @impl GenServer
+  def handle_call(:get_snapshots, _from, state) do
+    if state.persistence_options == nil do
+      {:reply, [], state}
+    else
+      {:reply, Persist.get_snapshot_list(state.persistence_options), state}
+    end
+  end
+
+  @impl GenServer
+  def handle_info(:persist, state) do
+    Persist.persist_to_disk(state.table, state.persistence_options)
+    {:noreply, state}
+  end
+
   defp match_with_timestamp(table, matcher, pattern) do
     :ets.foldl(
       fn {property, value, timestamp}, acc ->
@@ -290,4 +402,12 @@ defmodule PropertyTable.Updater do
   end
 
   defp compute_events([], _state, acc), do: acc
+
+  defp maybe_setup_persistence(nil), do: :ok
+
+  defp maybe_setup_persistence(options) when is_list(options) do
+    if Keyword.has_key?(options, :interval) do
+      :timer.send_interval(options[:interval], :persist)
+    end
+  end
 end

--- a/lib/property_table/updater.ex
+++ b/lib/property_table/updater.ex
@@ -48,7 +48,9 @@ defmodule PropertyTable.Updater do
     end
 
     case Persist.restore_from_disk(table_name, persistence_options) do
-      :ok -> :ok
+      :ok ->
+        :ok
+
       {:error, _error_reason} ->
         create_ets_table(table_name, initial_properties)
     end

--- a/lib/property_table/updater.ex
+++ b/lib/property_table/updater.ex
@@ -316,6 +316,12 @@ defmodule PropertyTable.Updater do
     {:reply, :ok, state}
   end
 
+  @impl GenServer
+  def handle_info(:persist, state) do
+    Persist.persist_to_disk(state.table, state.persistence_options)
+    {:noreply, state}
+  end
+
   defp match_with_timestamp(table, matcher, pattern) do
     :ets.foldl(
       fn {property, value, timestamp}, acc ->

--- a/lib/property_table/updater.ex
+++ b/lib/property_table/updater.ex
@@ -157,7 +157,7 @@ defmodule PropertyTable.Updater do
   """
   @spec flush_to_disk(PropertyTable.table_id()) :: :ok
   def flush_to_disk(table) do
-    send(server_name(table), :persist)
+    GenServer.call(server_name(table), :persist)
     :ok
   end
 
@@ -311,9 +311,9 @@ defmodule PropertyTable.Updater do
   end
 
   @impl GenServer
-  def handle_info(:persist, state) do
+  def handle_call(:persist, _from, state) do
     Persist.persist_to_disk(state.table, state.persistence_options)
-    {:noreply, state}
+    {:reply, :ok, state}
   end
 
   defp match_with_timestamp(table, matcher, pattern) do

--- a/test/persist/property_table_persist_test.exs
+++ b/test/persist/property_table_persist_test.exs
@@ -1,7 +1,7 @@
 defmodule PropertyTablePersistTest do
   use ExUnit.Case
 
-  # @moduletag :capture_log
+  @moduletag :capture_log
 
   @corrupted_table_test_name CorruptTableTest
 
@@ -104,7 +104,7 @@ defmodule PropertyTablePersistTest do
     assert PropertyTable.restore_snapshot(table, "some_id") == :noop
   end
 
-  test "PropertyTable should restore a backup file if present" do
+  test "PropertyTable should restore a backup file if the stable file is corrupted" do
     table = @corrupted_table_test_name
     persist_path = System.tmp_dir!()
 

--- a/test/persist/property_table_persist_test.exs
+++ b/test/persist/property_table_persist_test.exs
@@ -49,7 +49,9 @@ defmodule PropertyTablePersistTest do
       )
 
     {:ok, _snapshot_id_0} = PropertyTable.snapshot(table)
+    :timer.sleep(1000)
     {:ok, snapshot_id_1} = PropertyTable.snapshot(table)
+    :timer.sleep(1000)
     {:ok, snapshot_id_2} = PropertyTable.snapshot(table)
 
     assert [
@@ -58,7 +60,7 @@ defmodule PropertyTablePersistTest do
            ] = PropertyTable.get_snapshots(table)
   end
 
-  test "PropertyTable.get_snapshots/1 should return a list of all current snapshots on disk", %{
+  test "PropertyTable.get_snapshots/1 should return a list of all current snapshots on disk in order of oldest to newest", %{
     table_name: table,
     path: persist_path
   } do
@@ -67,11 +69,13 @@ defmodule PropertyTablePersistTest do
         {PropertyTable, name: table, persist_data_path: persist_path, persist_max_snapshots: 5}
       )
 
-    {:ok, _id} = PropertyTable.snapshot(table)
-    {:ok, _id} = PropertyTable.snapshot(table)
-    {:ok, _id} = PropertyTable.snapshot(table)
+    {:ok, id_oldest} = PropertyTable.snapshot(table)
+    :timer.sleep(1000)
+    {:ok, id_middle} = PropertyTable.snapshot(table)
+    :timer.sleep(1000)
+    {:ok, id_newest} = PropertyTable.snapshot(table)
 
-    assert length(PropertyTable.get_snapshots(table)) == 3
+    assert [id_oldest, id_middle, id_newest] == PropertyTable.get_snapshots(table) |> Enum.map(fn {id, _} -> id end)
   end
 
   test "PropertyTable.restore_snapshot/1 should return a table to a previous snapshot state", %{

--- a/test/persist/property_table_persist_test.exs
+++ b/test/persist/property_table_persist_test.exs
@@ -116,8 +116,8 @@ defmodule PropertyTablePersistTest do
 
     Process.exit(pid, :normal)
 
-    stable_path = Path.join(persist_path, ["#{table}", "/prop_table.db"])
-    backup_path = Path.join(persist_path, ["#{table}", "/prop_table.db.backup"])
+    stable_path = Path.join(persist_path, ["#{table}", "/data.ptable"])
+    backup_path = Path.join(persist_path, ["#{table}", "/data.ptable.backup"])
 
     File.copy!(stable_path, backup_path)
 

--- a/test/persist/property_table_persist_test.exs
+++ b/test/persist/property_table_persist_test.exs
@@ -1,0 +1,104 @@
+defmodule PropertyTablePersistTest do
+  use ExUnit.Case
+
+  @moduletag :capture_log
+
+  setup do
+    table_name = :crypto.strong_rand_bytes(8) |> Base.encode16()
+    path = System.tmp_dir!()
+
+    [table_name: String.to_atom(table_name), path: path]
+  end
+
+  test "PropertyTable.flush_to_disk/1 should save table to disk immediately", %{
+    table_name: table,
+    path: persist_path
+  } do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table, persist_data_path: persist_path})
+
+    PropertyTable.flush_to_disk(table)
+
+    # Ensure the file was written
+    check_path = Path.join(persist_path, [to_string(table)])
+    assert File.exists?(check_path)
+  end
+
+  test "PropertyTable.snapshot/1 should save a snapshot to disk", %{
+    table_name: table,
+    path: persist_path
+  } do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table, persist_data_path: persist_path})
+
+    {:ok, snapshot_id} = PropertyTable.snapshot(table)
+
+    # Ensure the snapshot was written
+    [{found_snapshot_id, _}] = PropertyTable.get_snapshots(table)
+    assert found_snapshot_id == snapshot_id
+  end
+
+  test "PropertyTable.snapshot/1 should replace the oldest snapshot with a new one when limit is reached",
+       %{
+         table_name: table,
+         path: persist_path
+       } do
+    {:ok, _pid} =
+      start_supervised(
+        {PropertyTable, name: table, persist_data_path: persist_path, persist_max_snapshots: 2}
+      )
+
+    {:ok, _snapshot_id_0} = PropertyTable.snapshot(table)
+    {:ok, snapshot_id_1} = PropertyTable.snapshot(table)
+    {:ok, snapshot_id_2} = PropertyTable.snapshot(table)
+
+    assert [
+             {^snapshot_id_1, _},
+             {^snapshot_id_2, _}
+           ] = PropertyTable.get_snapshots(table)
+  end
+
+  test "PropertyTable.get_snapshots/1 should return a list of all current snapshots on disk", %{
+    table_name: table,
+    path: persist_path
+  } do
+    {:ok, _pid} =
+      start_supervised(
+        {PropertyTable, name: table, persist_data_path: persist_path, persist_max_snapshots: 5}
+      )
+
+    {:ok, _id} = PropertyTable.snapshot(table)
+    {:ok, _id} = PropertyTable.snapshot(table)
+    {:ok, _id} = PropertyTable.snapshot(table)
+
+    assert length(PropertyTable.get_snapshots(table)) == 3
+  end
+
+  test "PropertyTable.restore_snapshot/1 should return a table to a previous snapshot state", %{
+    table_name: table,
+    path: persist_path
+  } do
+    {:ok, _pid} =
+      start_supervised(
+        {PropertyTable, name: table, persist_data_path: persist_path, persist_max_snapshots: 5}
+      )
+
+    # set initial property then snapshot
+    PropertyTable.put(table, ["property", "test", "a"], :original_value)
+    {:ok, snapshot_id} = PropertyTable.snapshot(table)
+
+    # change the property
+    PropertyTable.put(table, ["property", "test", "a"], :new_value)
+
+    # restore and check the value
+    PropertyTable.restore_snapshot(table, snapshot_id)
+    assert PropertyTable.get(table, ["property", "test", "a"]) == :original_value
+  end
+
+  test "Calling and of the persistent/snapshot methods on a non-persistent table will simply noop",
+       %{
+         table_name: table
+       } do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table})
+    assert PropertyTable.snapshot(table) == :noop
+    assert PropertyTable.restore_snapshot(table, "some_id") == :noop
+  end
+end

--- a/test/persist/property_table_persist_test.exs
+++ b/test/persist/property_table_persist_test.exs
@@ -60,10 +60,11 @@ defmodule PropertyTablePersistTest do
            ] = PropertyTable.get_snapshots(table)
   end
 
-  test "PropertyTable.get_snapshots/1 should return a list of all current snapshots on disk in order of oldest to newest", %{
-    table_name: table,
-    path: persist_path
-  } do
+  test "PropertyTable.get_snapshots/1 should return a list of all current snapshots on disk in order of oldest to newest",
+       %{
+         table_name: table,
+         path: persist_path
+       } do
     {:ok, _pid} =
       start_supervised(
         {PropertyTable, name: table, persist_data_path: persist_path, persist_max_snapshots: 5}
@@ -75,7 +76,8 @@ defmodule PropertyTablePersistTest do
     :timer.sleep(1000)
     {:ok, id_newest} = PropertyTable.snapshot(table)
 
-    assert [id_oldest, id_middle, id_newest] == PropertyTable.get_snapshots(table) |> Enum.map(fn {id, _} -> id end)
+    assert [id_oldest, id_middle, id_newest] ==
+             PropertyTable.get_snapshots(table) |> Enum.map(fn {id, _} -> id end)
   end
 
   test "PropertyTable.restore_snapshot/1 should return a table to a previous snapshot state", %{

--- a/test/persist/property_table_persist_test.exs
+++ b/test/persist/property_table_persist_test.exs
@@ -95,7 +95,7 @@ defmodule PropertyTablePersistTest do
     assert PropertyTable.get(table, ["property", "test", "a"]) == :original_value
   end
 
-  test "Calling and of the persistent/snapshot methods on a non-persistent table will simply noop",
+  test "Calling the persistent/snapshot methods on a non-persistent table will simply noop",
        %{
          table_name: table
        } do

--- a/test/persist/property_table_persist_test.exs
+++ b/test/persist/property_table_persist_test.exs
@@ -126,7 +126,7 @@ defmodule PropertyTablePersistTest do
     File.write!(stable_path, random_content, [:binary])
 
     # Reboot the table, it should restore the backup file
-    {:ok, pid} = start_supervised({PropertyTable, name: table, persist_data_path: persist_path})
+    {:ok, _pid} = start_supervised({PropertyTable, name: table, persist_data_path: persist_path})
 
     assert PropertyTable.get(table, ["test"]) == :test_value
   end


### PR DESCRIPTION
This PR adds new options when starting up a property table. 

New Options:

  * `:persist_data_path` - set to a directory where PropertyTable will
    persist the contents of the table to disk, snapshots will also be stored here.
  * `:persist_interval` - if set PropertyTable will persist the contents of
    tables to disk in intervals of the provided value (in milliseconds) automatically.
  * `:persist_max_snapshots` - Maximum number of manual snapshots to keep on disk before they
    are replaced - (oldest snapshots are replaced first.)
  * `:persist_compression` - `0..9` range to compress the terms when written to disk, see `:erlang.term_to_binary/2`



For example:

```elixir
PropertyTable.start_link(name: MyTable, persist_data_path: "data/", persist_interval: 30_000)
```

The above line will start a property table as expected, but every 30 seconds, it will persist to the disk at directory `data/Elixir.MyTable` (directory name is automatically derived from the Atom name of the table.)

When persisting we do the following:

1. Move the current persistent file (know as the stable file) to a backup name.
2. Write the current contents of the table to a new stable file.

This ordering helps ensure that if we are interrupted (via a power outage or app crash) during any of these single operations, we can still recover good data. If we are interrupted during the writing of the file, the backup file will be restored in place next time the table is starting up.

You can also take manual "snapshots" by doing the following:

```elixir
{:ok, snapshot_id} = PropertyTable.snapshot(MyTable)
```

This will persist the table immediately, then place a copy of the current table's stable file into a `snapshots/` directory in the data path. Snapshots can be restored using `PropertyTable.restore_snapshot(MyTable, snapshot_id)`

Test Coverage Report:

```perl
Percentage | Module
-----------|--------------------------
    89.58% | PropertyTable
    90.00% | PropertyTable.Updater
    92.31% | PropertyTable.Matcher.StringPath
   100.00% | PropertyTable.Event
   100.00% | PropertyTable.Matcher
   100.00% | PropertyTable.Persist
   100.00% | PropertyTable.Supervisor
-----------|--------------------------
    93.39% | Total
```