### PR TITLE
Fix missing :crypto dependency warning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule PropertyTable.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:crypto, :logger]
     ]
   end
 


### PR DESCRIPTION
The :crypto dependency was added with the persistence feature. This
fixes the missing dependency warning when compiled as part of another
project.
