### PR TITLE
Don't crash when saves fail

### DIFF
--- a/lib/property_table/persist.ex
+++ b/lib/property_table/persist.ex
@@ -151,7 +151,7 @@ defmodule PropertyTable.Persist do
   rescue
     e ->
       Logger.error(
-        "Failed to copy snapshot in place, could not read or copy the snapshot file! - #{e}"
+        "Failed to copy snapshot in place, could not read or copy the snapshot file! - #{inspect(e)}"
       )
 
       {:error, :enoent}

--- a/lib/property_table/persist.ex
+++ b/lib/property_table/persist.ex
@@ -128,7 +128,7 @@ defmodule PropertyTable.Persist do
     {:ok, snapshot_id}
   rescue
     e ->
-      Logger.error("Failed to save snapshot to disk: #{e}")
+      Logger.error("Failed to save snapshot to disk: #{inspect(e)}")
       :error
   end
 

--- a/lib/property_table/persist.ex
+++ b/lib/property_table/persist.ex
@@ -62,7 +62,7 @@ defmodule PropertyTable.Persist do
     :ok
   rescue
     e ->
-      Logger.error("Failed to persist table to disk: #{e}")
+      Logger.error("Failed to persist table to disk: #{inspect(e)}")
       :error
   end
 
@@ -104,7 +104,7 @@ defmodule PropertyTable.Persist do
     end
   rescue
     e ->
-      Logger.error("Failed to restore table from disk: #{e}")
+      Logger.error("Failed to restore table from disk: #{inspect(e)}")
       {:error, :failed_to_restore}
   end
 

--- a/lib/property_table/updater.ex
+++ b/lib/property_table/updater.ex
@@ -265,8 +265,8 @@ defmodule PropertyTable.Updater do
     if state.persistence_options == nil do
       {:reply, :noop, state}
     else
-      {:ok, snapshot_id} = Persist.save_snapshot(state.table, state.persistence_options)
-      {:reply, {:ok, snapshot_id}, state}
+      result = Persist.save_snapshot(state.table, state.persistence_options)
+      {:reply, result, state}
     end
   end
 

--- a/test/property_table/persist_test.exs
+++ b/test/property_table/persist_test.exs
@@ -135,7 +135,7 @@ defmodule PropertyTable.PersistTest do
     assert PropertyTable.get(table, ["test"]) == :test_value
   end
 
-  test "file system failures get logged", %{table_name: table} do
+  test "flush failures get logged", %{table_name: table} do
     start_supervised!(
       {PropertyTable, name: table, persist_data_path: "/sys/class/this_will_never_work/"}
     )
@@ -144,5 +144,16 @@ defmodule PropertyTable.PersistTest do
 
     # Flushing will succeed, but make sure an error is logged.
     assert log =~ "Failed to persist table"
+  end
+
+  test "snapshot failures get logged", %{table_name: table} do
+    start_supervised!(
+      {PropertyTable, name: table, persist_data_path: "/sys/class/this_will_never_work/"}
+    )
+
+    log = capture_log(fn -> :error = PropertyTable.snapshot(table) end)
+
+    # Flushing will succeed, but make sure an error is logged.
+    assert log =~ "Failed to save snapshot"
   end
 end


### PR DESCRIPTION
This fixes an issue where an exception was raised when trying to prevent
an exception from being raised.
