### PR TITLE
Return or ignore filesystem errors explicitly

### DIFF
--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -289,7 +289,7 @@ defmodule PropertyTable do
   disk immediately. The table is already written every `:persist_interval`, but
   this is avoid waiting after important changes.
   """
-  @spec flush_to_disk(table_id()) :: :ok
+  @spec flush_to_disk(table_id()) :: :ok | {:error, any()}
   defdelegate flush_to_disk(table), to: Updater
 
   @doc """

--- a/lib/property_table/persist.ex
+++ b/lib/property_table/persist.ex
@@ -38,7 +38,7 @@ defmodule PropertyTable.Persist do
   @data_stable_name "data.ptable"
   @data_backup_name "data.ptable.backup"
 
-  @spec persist_to_disk(PropertyTable.table_id(), keyword()) :: :ok | :error
+  @spec persist_to_disk(PropertyTable.table_id(), keyword()) :: :ok | {:error, any()}
   def persist_to_disk(table, options) do
     options = take_options(options)
 
@@ -63,7 +63,7 @@ defmodule PropertyTable.Persist do
   rescue
     e ->
       Logger.error("Failed to persist table to disk: #{inspect(e)}")
-      :error
+      {:error, e}
   end
 
   @spec restore_from_disk(PropertyTable.table_id(), keyword()) :: :ok | {:error, atom()}
@@ -111,7 +111,7 @@ defmodule PropertyTable.Persist do
   @spec save_snapshot(PropertyTable.table_id(), keyword()) :: {:ok, String.t()} | :error
   def save_snapshot(table, options) do
     options = take_options(options)
-    persist_to_disk(table, options)
+    :ok = persist_to_disk(table, options)
 
     snapshot_id = :crypto.strong_rand_bytes(8) |> Base.encode16()
 

--- a/lib/property_table/updater.ex
+++ b/lib/property_table/updater.ex
@@ -142,10 +142,9 @@ defmodule PropertyTable.Updater do
   @doc """
   Save table to disk immediately (if persistence is configured)
   """
-  @spec flush_to_disk(PropertyTable.table_id()) :: :ok
+  @spec flush_to_disk(PropertyTable.table_id()) :: :ok | {:error, any()}
   def flush_to_disk(table) do
     GenServer.call(server_name(table), :persist)
-    :ok
   end
 
   @impl GenServer
@@ -298,13 +297,13 @@ defmodule PropertyTable.Updater do
 
   @impl GenServer
   def handle_call(:persist, _from, state) do
-    Persist.persist_to_disk(state.table, state.persistence_options)
-    {:reply, :ok, state}
+    result = Persist.persist_to_disk(state.table, state.persistence_options)
+    {:reply, result, state}
   end
 
   @impl GenServer
   def handle_info(:persist, state) do
-    Persist.persist_to_disk(state.table, state.persistence_options)
+    _ = Persist.persist_to_disk(state.table, state.persistence_options)
     {:noreply, state}
   end
 

--- a/test/property_table/persist_test.exs
+++ b/test/property_table/persist_test.exs
@@ -138,7 +138,7 @@ defmodule PropertyTable.PersistTest do
       {PropertyTable, name: table, persist_data_path: "/sys/class/this_will_never_work/"}
     )
 
-    log = capture_log(fn -> :ok = PropertyTable.flush_to_disk(table) end)
+    log = capture_log(fn -> {:error, _} = PropertyTable.flush_to_disk(table) end)
 
     # Flushing will succeed, but make sure an error is logged.
     assert log =~ "Failed to persist table"


### PR DESCRIPTION
This fixes Dialyzer unmatched return errors that were being hidden and
it also makes it possible for users to see if persistence fails without
inspecting logs. Realistically, users still need to review the logs
since most writes probably are done automatically by PropertyTable.
