### PR TITLE
Add dependabot automerge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ latest: &latest
 
 tags: &tags
   [
-    1.15.4-erlang-26.0.2-alpine-3.18.2,
+    1.15.7-erlang-26.1.2-alpine-3.18.4,
     1.14.5-erlang-25.3.2-alpine-3.18.0,
     1.13.4-erlang-25.3.2-alpine-3.18.0,
     1.12.3-erlang-24.3.4.11-alpine-3.18.0,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,15 @@ version: 2.1
 latest: &latest
   pattern: "^1.15.*-erlang-26.*$"
 
+tags: &tags
+  [
+    1.15.4-erlang-26.0.2-alpine-3.18.2,
+    1.14.5-erlang-25.3.2-alpine-3.18.0,
+    1.13.4-erlang-25.3.2-alpine-3.18.0,
+    1.12.3-erlang-24.3.4.11-alpine-3.18.0,
+    1.11.4-erlang-23.3.4.13-alpine-3.15.3
+  ]
+
 jobs:
   build-test:
     parameters:
@@ -45,6 +54,24 @@ jobs:
             - _build
             - deps
 
+  automerge:
+    docker:
+        - image: alpine:3.18.4
+    steps:
+      - run:
+          name: Install GitHub CLI
+          command: apk add --no-cache build-base github-cli
+      - run:
+          name: Attempt PR automerge
+          command: |
+            author=$(gh pr view "${CIRCLE_PULL_REQUEST}" --json author --jq '.author.login' || true)
+
+            if [ "$author" = "app/dependabot" ]; then
+              gh pr merge "${CIRCLE_PULL_REQUEST}" --auto --rebase || echo "Failed trying to set automerge"
+            else
+              echo "Not a dependabot PR, skipping automerge"
+            fi
+
 workflows:
   checks:
     jobs:
@@ -52,10 +79,11 @@ workflows:
           name: << matrix.tag >>
           matrix:
             parameters:
-              tag: [
-                1.15.4-erlang-26.0.2-alpine-3.18.2,
-                1.14.5-erlang-25.3.2-alpine-3.18.0,
-                1.13.4-erlang-25.3.2-alpine-3.18.0,
-                1.12.3-erlang-24.3.4.11-alpine-3.18.0,
-                1.11.4-erlang-23.3.4.13-alpine-3.15.3
-              ]
+              tag: *tags
+
+      - automerge:
+          requires: *tags
+          context: org-global
+          filters:
+            branches:
+              only: /^dependabot.*/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+
+updates:
+  - package-ecosystem: mix
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Adds an extra job that will run only on dependabot PR's, require all previous jobs to be successful, and require the PR was created by dependabot. If all conditions are met, it will automatically merge the dependabot PR