### PR TITLE
Fix incorrect typespec on 'options'

### DIFF
--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -52,7 +52,16 @@ defmodule PropertyTable do
 
   See `start_link/1` for usage.
   """
-  @type options() :: [name: table_id(), properties: [property_value()], tuple_events: boolean()]
+  @type options() :: [
+          name: table_id(),
+          properties: [property_value()],
+          tuple_events: boolean(),
+          matcher: module(),
+          persist_data_path: String.t(),
+          persist_interval: pos_integer(),
+          persist_max_snapshots: pos_integer(),
+          persist_compression: 0..9
+        ]
 
   @doc """
   Start a PropertyTable's supervision tree


### PR DESCRIPTION
Specifies: `:matcher`, `:persist_data_path`, `:persist_interval`, `:persist_max_snapshots`, and `:persist_compression` options in the `options()` typespec.

This stops dialyzer from complaining about a vague `no local return` when using `start_link/1` in a function.