### PR TITLE
Support custom event types

### DIFF
--- a/lib/property_table/supervisor.ex
+++ b/lib/property_table/supervisor.ex
@@ -10,7 +10,7 @@ defmodule PropertyTable.Supervisor do
       matcher: options.matcher,
       registry: registry_name,
       table: options.table,
-      tuple_events: options.tuple_events,
+      event_transformer: options.event_transformer,
       persistence_options: options.persistence_options
     }
 

--- a/lib/property_table/updater.ex
+++ b/lib/property_table/updater.ex
@@ -14,7 +14,7 @@ defmodule PropertyTable.Updater do
   @type state() :: %{
           table: PropertyTable.table_id(),
           registry: Registry.registry(),
-          tuple_events: boolean(),
+          event_transformer: (Event.t() -> any),
           matcher: module()
         }
 
@@ -322,7 +322,7 @@ defmodule PropertyTable.Updater do
   end
 
   defp dispatch(state, event) do
-    message = if state.tuple_events, do: Event.to_tuple(event), else: event
+    message = state.event_transformer.(event)
     matcher = state.matcher
     property = event.property
 

--- a/test/property_table_test.exs
+++ b/test/property_table_test.exs
@@ -327,6 +327,19 @@ defmodule PropertyTableTest do
     assert_receive {^table, ^property, nil, 101, %{old_timestamp: _, new_timestamp: _}}
   end
 
+  test "custom event transformer", %{test: table} do
+    start_supervised!(
+      {PropertyTable, name: table, event_transformer: fn e -> "My event is #{e.value}" end}
+    )
+
+    property = ["test", "a", "b"]
+
+    PropertyTable.subscribe(table, [])
+    PropertyTable.put(table, property, "awesome")
+    assert_receive "My event is awesome"
+    refute_receive _
+  end
+
   test "rejects bad properties", %{test: table} do
     start_supervised!({PropertyTable, name: table})
 


### PR DESCRIPTION
This is nice when you're using PropertyTable inside another library and
don't want to expose the implementation.

This also rewrites support for the legacy tuple method to use the more
generic event transformer.
