### PR TITLE
Set event previous timestamps as best as possible

### DIFF
--- a/lib/property_table/persist.ex
+++ b/lib/property_table/persist.ex
@@ -74,8 +74,9 @@ defmodule PropertyTable.Persist do
       {:error, e}
   end
 
-  @spec restore_from_disk(PropertyTable.table_id(), keyword()) :: :ok | {:error, atom()}
-  def restore_from_disk(table, options) do
+  @spec restore_from_disk(PropertyTable.table_id(), keyword(), integer()) ::
+          :ok | {:error, atom()}
+  def restore_from_disk(table, options, timestamp) do
     options = take_options(options)
 
     stable_path = data_file_path(options)
@@ -97,9 +98,6 @@ defmodule PropertyTable.Persist do
     case result do
       {:ok, data} ->
         ^table = :ets.new(table, [:named_table, :public])
-
-        # Insert the restored properties at the current timestamp
-        timestamp = System.monotonic_time()
 
         Enum.each(data, fn {property, value} ->
           :ets.insert(table, {property, value, timestamp})

--- a/lib/property_table/supervisor.ex
+++ b/lib/property_table/supervisor.ex
@@ -5,13 +5,15 @@ defmodule PropertyTable.Supervisor do
   @impl Supervisor
   def init(options) do
     registry_name = registry_name(options.table)
+    start_time = System.monotonic_time()
 
     table_options = %{
       matcher: options.matcher,
       registry: registry_name,
       table: options.table,
       event_transformer: options.event_transformer,
-      persistence_options: options.persistence_options
+      persistence_options: options.persistence_options,
+      start_time: start_time
     }
 
     # Try and restore from disk if persistence options are provided
@@ -20,10 +22,11 @@ defmodule PropertyTable.Supervisor do
       PropertyTable.Updater.maybe_restore_ets_table(
         options.table,
         options.properties,
-        options.persistence_options
+        options.persistence_options,
+        start_time
       )
     else
-      PropertyTable.Updater.create_ets_table(options.table, options.properties)
+      PropertyTable.Updater.create_ets_table(options.table, options.properties, start_time)
     end
 
     children = [


### PR DESCRIPTION
Previously when events were sent on a property for the first time, the
`previous_timestamp` was `nil`. This was a typespec violation, but it
also made it hard to know how long the property was in the unknown
state. Depending on the use, an application could infer a default value
on the property. It could also assign an "unknown" value. Either way, it
could be useful to know how long it was in this state and `nil` didn't
help.

A side effect of this change is that all values set explicitly or
implicitly at startup will have the same timestamp. This could come in
handy.
