### PR TITLE
Add PropertyTable.get_all_with_timestamps/0

### DIFF
--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -234,7 +234,8 @@ defmodule PropertyTable do
   @doc """
   Fetch a property with the time that it was set
 
-  Timestamps come from `System.monotonic_time()`
+  Timestamps come from `System.monotonic_time()`. Use
+  `System.convert_time_unit/3` to convert from native time units.
   """
   @spec fetch_with_timestamp(table_id(), property()) :: {:ok, value(), integer()} | :error
   def fetch_with_timestamp(table, property) do
@@ -258,6 +259,18 @@ defmodule PropertyTable do
       [],
       table
     )
+  end
+
+  @doc """
+  Get all properties with timestamps
+
+  This function is similar to `get_all/1` but also returns the monotonic
+  time that the property was set. Use `System.convert_time_unit/3` to convert
+  from native time units.
+  """
+  @spec get_all_with_timestamps(table_id()) :: [{property(), value(), integer()}]
+  def get_all_with_timestamps(table) do
+    :ets.tab2list(table)
   end
 
   @doc """

--- a/test/property_table_test.exs
+++ b/test/property_table_test.exs
@@ -449,4 +449,18 @@ defmodule PropertyTableTest do
     PropertyTable.put_many(table, [{property1, 3}, {property2, 5}])
     refute_receive _
   end
+
+  test "put_many puts all with the same timestamp", %{test: table} do
+    start_supervised!({PropertyTable, name: table})
+    property1 = ["test", "a", "b"]
+    property2 = ["test", "a", "c"]
+    property3 = ["test", "a", "d"]
+
+    PropertyTable.put_many(table, [{property1, 1}, {property2, 2}, {property3, 3}])
+
+    [{_, _, ts1}, {_, _, ts2}, {_, _, ts3}] = PropertyTable.get_all_with_timestamps(table)
+
+    assert ts1 == ts2
+    assert ts1 == ts3
+  end
 end


### PR DESCRIPTION
These were needed for an informational dump of everything in a
PropertyTable. Having the last change timestamp was super helpful.
