### PR TITLE
Add Matcher.match_spec/1 to improve match performance

### DIFF
--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -281,6 +281,19 @@ defmodule PropertyTable do
     registry = PropertyTable.Supervisor.registry_name(table)
     {:ok, matcher} = Registry.meta(registry, :matcher)
 
+    with true <- function_exported?(matcher, :match_spec, 1),
+         spec when is_list(spec) <- matcher.match_spec(pattern) do
+      match_via_spec(table, spec)
+    else
+      _ -> match_via_foldl(table, matcher, pattern)
+    end
+  end
+
+  defp match_via_spec(table, spec) do
+    for {property, value, _meta} <- :ets.select(table, spec), do: {property, value}
+  end
+
+  defp match_via_foldl(table, matcher, pattern) do
     :ets.foldl(
       fn {property, value, _timestamp}, acc ->
         if matcher.matches?(pattern, property) do

--- a/lib/property_table/matcher.ex
+++ b/lib/property_table/matcher.ex
@@ -27,4 +27,20 @@ defmodule PropertyTable.Matcher do
   Returns true if the pattern matches the specified property
   """
   @callback matches?(PropertyTable.pattern(), PropertyTable.property()) :: boolean()
+
+  @doc """
+  Build an ETS match-spec for `pattern`
+
+  This is an optional callback. When implemented, `PropertyTable.match/2` will
+  call it to obtain a match-spec and run the scan with `:ets.select/2`. This can
+  be much faster on large tables than iterating over rows calling `matches?/2`.
+  Return `:error` to fall back to the generic `matches?/2` path.
+
+  The match-spec must handle `{property, value, meta}` triples. Return
+  rows unmodified by specifying `[:"$_"]` in the third tuple element.
+  """
+  @callback match_spec(PropertyTable.pattern()) ::
+              [{tuple(), [term()], [term()]}] | :error
+
+  @optional_callbacks match_spec: 1
 end

--- a/lib/property_table/matcher/string_path.ex
+++ b/lib/property_table/matcher/string_path.ex
@@ -78,4 +78,25 @@ defmodule PropertyTable.Matcher.StringPath do
   def matches?([], _property), do: true
   def matches?([:"$"], []), do: true
   def matches?(_pattern, _property), do: false
+
+  @doc """
+  Build an ETS match-spec equivalent to `matches?/2` for `pattern`
+
+  StringPath patterns translate directly into list patterns in the match-spec
+  head: `:_` is already an ETS wildcard, and the tail is left open with `:_`
+  unless the pattern ends in `:"$"`, in which case it is `[]` to anchor the
+  length. The body returns the whole row via `:"$_"`, so PropertyTable does
+  not need to know the row layout. Returns `:error` for invalid patterns.
+  """
+  @impl PropertyTable.Matcher
+  def match_spec(pattern) do
+    case check_pattern(pattern) do
+      :ok -> [{{property_pattern(pattern), :_, :_}, [], [:"$_"]}]
+      {:error, _} -> :error
+    end
+  end
+
+  defp property_pattern([]), do: :_
+  defp property_pattern([:"$"]), do: []
+  defp property_pattern([seg | rest]), do: [seg | property_pattern(rest)]
 end

--- a/test/property_table/matcher/string_path_test.exs
+++ b/test/property_table/matcher/string_path_test.exs
@@ -50,4 +50,106 @@ defmodule PropertyTable.Matcher.StringPathTest do
     refute StringPath.matches?([:_, "22"], ["1", "2"])
     refute StringPath.matches?(["11", :_], ["1", "2"])
   end
+
+  describe "match_spec/1 via :ets.select/2" do
+    setup do
+      %{tbl: :ets.new(:main_table, [:set, :private])}
+    end
+
+    test "invalid patterns return :error" do
+      assert StringPath.match_spec(nil) == :error
+      assert StringPath.match_spec("oops") == :error
+      assert StringPath.match_spec([123]) == :error
+    end
+
+    test "empty pattern returns every row", %{tbl: tbl} do
+      insert_property(tbl, [], :v_empty)
+      insert_property(tbl, ["a"], :v_a)
+      insert_property(tbl, ["a", "b", "c"], :v_abc)
+
+      assert Enum.sort(match_all(tbl, [])) ==
+               [{[], :v_empty}, {["a"], :v_a}, {["a", "b", "c"], :v_abc}]
+    end
+
+    test "[:$] returns only the empty property", %{tbl: tbl} do
+      insert_property(tbl, [], :v_empty)
+      insert_property(tbl, ["a"], :v_a)
+
+      assert match_all(tbl, [:"$"]) == [{[], :v_empty}]
+    end
+
+    test "literal prefix returns matching subtree", %{tbl: tbl} do
+      insert_property(tbl, ["a"], :v_a)
+      insert_property(tbl, ["a", "b"], :v_ab)
+      insert_property(tbl, ["a", "b", "c"], :v_abc)
+      insert_property(tbl, ["b"], :v_b)
+
+      assert Enum.sort(match_all(tbl, ["a"])) ==
+               [{["a"], :v_a}, {["a", "b"], :v_ab}, {["a", "b", "c"], :v_abc}]
+    end
+
+    test ":_ wildcard returns any single segment at that position", %{tbl: tbl} do
+      insert_property(tbl, ["a", "x"], :v_ax)
+      insert_property(tbl, ["a", "y"], :v_ay)
+      insert_property(tbl, ["a"], :v_a)
+      insert_property(tbl, ["b", "x"], :v_bx)
+
+      assert Enum.sort(match_all(tbl, ["a", :_])) ==
+               [{["a", "x"], :v_ax}, {["a", "y"], :v_ay}]
+    end
+
+    test "anchored pattern requires exact length", %{tbl: tbl} do
+      insert_property(tbl, ["a"], :v_a)
+      insert_property(tbl, ["a", "b"], :v_ab)
+      insert_property(tbl, ["a", "b", "c"], :v_abc)
+
+      assert match_all(tbl, ["a", "b", :"$"]) == [{["a", "b"], :v_ab}]
+    end
+
+    test "parity with matches?/2 for all patterns and properties up to length 3",
+         %{tbl: tbl} do
+      pattern_segments = ["a", "b", :_, :"$"]
+      property_segments = ["a", "b", "c"]
+
+      patterns = Enum.flat_map(0..3, &tuples_of(pattern_segments, &1))
+      properties = Enum.flat_map(0..3, &tuples_of(property_segments, &1))
+
+      for property <- properties do
+        insert_property(tbl, property, property)
+      end
+
+      for pattern <- patterns do
+        expected =
+          properties
+          |> Enum.filter(&StringPath.matches?(pattern, &1))
+          |> Enum.map(&{&1, &1})
+          |> Enum.sort()
+
+        actual = match_all(tbl, pattern) |> Enum.sort()
+
+        assert expected == actual,
+               """
+               parity mismatch for pattern #{inspect(pattern)}
+                 expected (via StringPath.matches?/2): #{inspect(expected)}
+                 actual   (via ETS match-spec):       #{inspect(actual)}
+               """
+      end
+    end
+  end
+
+  defp insert_property(tbl, property, value) do
+    :ets.insert(tbl, {property, value, 0})
+  end
+
+  defp match_all(tbl, pattern) do
+    for {property, value, _meta} <- :ets.select(tbl, StringPath.match_spec(pattern)),
+        do: {property, value}
+  end
+
+  defp tuples_of(_choices, 0), do: [[]]
+
+  defp tuples_of(choices, n) do
+    shorter = tuples_of(choices, n - 1)
+    for c <- choices, rest <- shorter, do: [c | rest]
+  end
 end

--- a/test/property_table_test.exs
+++ b/test/property_table_test.exs
@@ -3,6 +3,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+defmodule PropertyTableTest.NoMatchSpecMatcher do
+  @moduledoc false
+  # Matcher that intentionally omits the optional match_spec/1 callback so
+  # PropertyTable.match/2 falls back to the foldl path.
+
+  @behaviour PropertyTable.Matcher
+
+  alias PropertyTable.Matcher.StringPath
+
+  @impl PropertyTable.Matcher
+  defdelegate check_property(property), to: StringPath
+
+  @impl PropertyTable.Matcher
+  defdelegate check_pattern(pattern), to: StringPath
+
+  @impl PropertyTable.Matcher
+  defdelegate matches?(pattern, property), to: StringPath
+end
+
 defmodule PropertyTableTest do
   use ExUnit.Case, async: true
 
@@ -333,6 +352,35 @@ defmodule PropertyTableTest do
              {["a", "b", "C"], 4},
              {["a", "b", "c"], 1}
            ]
+  end
+
+  test "match falls back to foldl when matcher omits match_spec/1", %{test: table} do
+    # Sanity check: the custom matcher must really lack match_spec/1 so the
+    # `function_exported?` guard in PropertyTable.match/2 fails and the foldl
+    # path is exercised.
+    refute function_exported?(PropertyTableTest.NoMatchSpecMatcher, :match_spec, 1)
+
+    start_supervised!({PropertyTable, name: table, matcher: PropertyTableTest.NoMatchSpecMatcher})
+
+    PropertyTable.put(table, ["a", "b", "c"], 1)
+    PropertyTable.put(table, ["a", "b", "d"], 2)
+    PropertyTable.put(table, ["x", "y"], 3)
+
+    assert deterministic_match(table, []) == [
+             {["a", "b", "c"], 1},
+             {["a", "b", "d"], 2},
+             {["x", "y"], 3}
+           ]
+
+    assert deterministic_match(table, ["a"]) == [{["a", "b", "c"], 1}, {["a", "b", "d"], 2}]
+
+    assert deterministic_match(table, ["a", "b", :_]) == [
+             {["a", "b", "c"], 1},
+             {["a", "b", "d"], 2}
+           ]
+
+    assert PropertyTable.match(table, ["x", "y", :"$"]) == [{["x", "y"], 3}]
+    assert PropertyTable.match(table, ["nope"]) == []
   end
 
   test "timestamp of old and new values are provided", %{test: table} do


### PR DESCRIPTION
This allows matchers to return ETS match specs for queries rather than
iterate through every property to see if it matches. ETS may still have
an O(n) runtime, but it will be in C rather than Elixir. Micro
benchmarks indicate a 30-50% performance improvement on a Raspberry Pi
5. This isn't that common of a use case for most people yet, though.
