### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # PropertyTable
 
 [![Hex version](https://img.shields.io/hexpm/v/property_table.svg "Hex version")](https://hex.pm/packages/property_table)
-[![API docs](https://img.shields.io/hexpm/v/property_table.svg?label=hexdocs "API docs")](https://hexdocs.pm/property_table/PropertyTable.html)
+[![API docs](https://img.shields.io/hexpm/v/property_table.svg?label=hexdocs "API docs")](https://property-table.hexdocs.pm/PropertyTable.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-project/property_table/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-project/property_table/tree/main)
 [![Coverage Status](https://coveralls.io/repos/github/nerves-project/property_table/badge.svg)](https://coveralls.io/github/nerves-project/property_table)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-project/property_table)](https://api.reuse.software/info/github.com/nerves-project/property_table)


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://property-table.hexdocs.pm/PropertyTable.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>